### PR TITLE
feat: Don't make rubicon a dylib?

### DIFF
--- a/rubicon/Cargo.toml
+++ b/rubicon/Cargo.toml
@@ -10,9 +10,6 @@ description = "Deduplicate globals across shared objects to enable a dangerous f
 categories = ["development-tools::ffi"]
 keywords = ["ffi", "thread-local"]
 
-[lib]
-crate-type = ["dylib"]
-
 [dependencies]
 libc = { version = "0.2.155", optional = true }
 paste = { version = "1.0.15", optional = true }


### PR DESCRIPTION
Since modules are build separately, they can't all have _their_ copy of librubicon? Well they can but it's annoying.